### PR TITLE
Expiry set to DateTime.Minvalue instead of DateTime.UtcNow

### DIFF
--- a/POGOLib.Core/Net/Authentication/Data/AccessToken.cs
+++ b/POGOLib.Core/Net/Authentication/Data/AccessToken.cs
@@ -29,7 +29,7 @@ namespace POGOLib.Official.Net.Authentication.Data
 
         public void Expire()
         {
-            Expiry = DateTime.UtcNow;
+            Expiry = DateTime.MinValue;
             AuthTicket = null;
             Token = null;
         }


### PR DESCRIPTION
If the function Expire and IsExpired are executed directly one after the other, the function IsExpired could result in a false negative.
Not every call to DateTime.UtcNow will result in a different time.

Try the following code and you see what i  mean:
using System;

namespace TestDateTime
{
    class Program
    {
        static void Main(string[] args)
        {

            var count = 0L;
            var token = new AccessToken();
            token.Expire();
            while(!token.IsExpired)
            {
                count++;
            }

            Console.WriteLine($"Count:{count}");
            Console.Write("Press <ENTER>");
            Console.ReadLine();
        }
    }

    public class AccessToken
    {
        public DateTime Expiry { get; set; }
        public bool IsExpired => DateTime.UtcNow > Expiry;
        public void Expire()
        {
            Expiry = DateTime.UtcNow;
        }
    }
}